### PR TITLE
sanitize volume before trying to process it

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -334,12 +334,15 @@ class BasePlugin:
         if Parameters["Mode3"] == "Volume":
             #self.tvVolume = _tv.get_volume_info()
             output = self.run("get-volume")#.replace("\\n'", "").replace("'", "").replace("b", "")
+            # Check if output is a digit instead of garbage
+            if not str(output).isdigit():
+                output = 0
             mute = self.run("get-mute")
             mute_level = 2
             if mute == "True":
                 mute_level = 0
             
-            Domoticz.Debug("vol: " + output)
+            Domoticz.Debug("vol: " + str(output))
             self.tvVolume = int(output)
             if self.tvVolume != None: UpdateDevice(2, mute_level, str(self.tvVolume))
                 


### PR DESCRIPTION
Fix #1

This gets rid of:

(55" LG TV) 'onHeartbeat' failed 'ValueError':'invalid literal for int() with base 10: 'Traceback (most recent call last):\n  File "/var/lib/domoticz/plugins/lgtv/lg.py", line 194, in <module>\n    main()\n  File "/var/lib/domoticz/plugins/lgtv/lg.py", line 189, in main\n    print(cmd.r'.

And fix the other error that surfaces after fixing the first:

(55" LG TV) Entering work loop.
(55" LG TV) 'onHeartbeat' failed 'TypeError':'Can't convert 'int' object to str implicitly'.
(55" LG TV) ----> Line 369 in /var/lib/domoticz/plugins/lgtv/plugin.py, function onHeartbeat
(55" LG TV) ----> Line 259 in /var/lib/domoticz/plugins/lgtv/plugin.py, function onHeartbeat
(55" LG TV) ----> Line 345 in /var/lib/domoticz/plugins/lgtv/plugin.py, function GetTVInfo