### PR TITLE
GetTVInfo: try parsing response before passing it on verbatim

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -307,7 +307,24 @@ class BasePlugin:
         Domoticz.Debug("Info: " + currentInfo)
 
         if not "errorCode" in currentChannel:#self.tvPlaying['programTitle'] != None:      # Get information on channel and program title if tuner of TV is used
-            self.tvPlaying = str(currentChannel + ' (' + currentInfo + ')' )
+            # pylgtv seems to return invalid JSON, so parse the fragment ourselves
+            if "channelName" in currentChannel:
+                currentChannelInfo = currentChannel.split(',')
+                currentChannelName = next((s for s in currentChannelInfo if 'channelName' in s), None).split('\'')[3]
+            else:
+                currentChannelName = None
+
+            if "channelNumber" in currentChannel:
+                currentChannelInfo = currentChannel.split(',')
+                currentChannelNumber = next((s for s in currentChannelInfo if 'channelNumber' in s), None).split('\'')[3]
+            else:
+                currentChannelNumber = None
+
+            if currentChannelNumber is not None:
+                self.tvPlaying = str(currentChannelNumber + ': ' + currentChannelName )
+            else:
+                self.tvPlaying = str(currentChannel + ' (' + currentInfo + ')' )
+
             UpdateDevice(1, 1, self.tvPlaying)
             self.tvSource = 10
             UpdateDevice(3, 1, str(self.tvSource))        # Set source device to TV


### PR DESCRIPTION
webOS 3.0 returns partial JSON, which the json module refuses to parse.
Parse it ourselves and fall back to the old behaviour if 'channelNumber'
isn't present in the reply.

Should fix #2 

Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>